### PR TITLE
Fix correct handling of alliance & solo licenses

### DIFF
--- a/mods/ScrapyardPlus/config/ScrapyardPlusConfig.lua
+++ b/mods/ScrapyardPlus/config/ScrapyardPlusConfig.lua
@@ -4,6 +4,7 @@ ScrapyardPlusConfig.version = "[1.1.0]"
 ScrapyardPlusConfig.modName = "[ScrapyardPlus]"
 ScrapyardPlusConfig.allowLifetime = true
 ScrapyardPlusConfig.lifetimeLevelFactor = 1.0
-ScrapyardPlusConfig.alliancePriceFactor = 5.0
+ScrapyardPlusConfig.alliancePriceFactor = 4.5
+ScrapyardPlusConfig.pricePerMinute = 175
 
 return ScrapyardPlusConfig


### PR DESCRIPTION
- only notify player once at each warning-time
- add coordinates to license-message
- make allianceFactor & pricePerMinute configurable
- fix check onHullHit to include alliance & private licenses
- adjusted reputationdiscount for alliance license