### PR TITLE
Fixed selling of ship to scrapyard

### DIFF
--- a/mods/ScrapyardPlus/scripts/entity/merchants/scrapyard.lua
+++ b/mods/ScrapyardPlus/scripts/entity/merchants/scrapyard.lua
@@ -8,7 +8,6 @@ local Dialog = require("dialogutility")
 
 -- Don't remove or alter the following comment, it tells the game the namespace this script lives in. If you remove it, the script will break.
 -- namespace Scrapyard
-Scrapyard = {}
 
 -- constants
 local MODULE = 'ScrapyardPlus' -- our module name


### PR DESCRIPTION
By re-initializing the Scrapyard object we threw away all vanilla functions.
So now we're able to use vanilla stuff like selling ships again.